### PR TITLE
Stop line buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "estream"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "estream"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Josh Mcguigan"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you are a Vim user, estream can help you unlock the power of the quickfix win
 Using vim-plug:
 
 ```vim
-Plug 'JoshMcguigan/estream', { 'do': 'bash install.sh v0.1.1' }
+Plug 'JoshMcguigan/estream', { 'do': 'bash install.sh v0.1.2' }
 
 " estream doesn't directly depend on asyncrun, but they work well together
 Plug 'skywind3000/asyncrun.vim'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,20 @@
 use std::{io, io::{Read, Write}};
 
-struct Tee<R, W> {
+pub struct Tee<R, W> {
     reader: R,
     writer: W,
+    buf: [u8; 8192],
+    len: usize,
 }
 
 impl<R, W> Tee<R, W> {
-    fn new(reader: R, writer: W) -> Self {
-        Self { reader, writer }
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer, buf: [0; 8192], len: 0 }
     }
 
-    fn into_inner(self) -> (R, W) {
-        (self.reader, self.writer)
+    #[cfg(test)]
+    fn get_writer_ref(&self) -> &W {
+        &self.writer
     }
 }
 
@@ -20,8 +23,24 @@ impl<R, W> Read for Tee<R, W>
           W: Write
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let len = self.reader.read(buf)?;
-        self.writer.write(&buf[0..len]);
+        let total_len = self.reader.read(&mut self.buf)?;
+        let newline_index = self.buf[0..total_len].iter().position(|b| *b == '\n' as u8);
+        let len = if let Some(newline_index) = newline_index {
+            newline_index + 1
+        } else {
+            total_len
+        };
+        self.writer.write(&self.buf[0..len])?;
+        &mut buf[0..len].copy_from_slice(&self.buf[0..len]);
+
+        if len < total_len {
+            // This means we didn't write out all of the bytes we got in. This is done
+            // to allow the reader a chance to process each line before we print any bytes
+            // on the next line, which gives the reader a chance to write their own bytes to
+            // standard out, without interleaving.
+
+            // copy total_len - len elements to start of self.buf, then set self.len
+        }
 
         Ok(len)
     }
@@ -64,12 +83,12 @@ mod tests {
     }
 
     #[test]
-    fn single_line() {
+    fn single_read() {
         let std_in = vec![
             String::from("testing"),
         ];
-        let mut mock_std_in = MockStdIn::new(std_in);
-        let mut mock_std_out = vec![];
+        let mock_std_in = MockStdIn::new(std_in);
+        let mock_std_out = vec![];
 
         let mut tee = Tee::new(mock_std_in, mock_std_out);
 
@@ -77,7 +96,50 @@ mod tests {
         assert_eq!(7, tee.read(&mut buf).unwrap());
         assert_eq!(b"testing", &buf[0..7]);
 
-        let (_, mock_std_out) = tee.into_inner();
+        let mock_std_out = tee.get_writer_ref();
         assert_eq!(b"testing", &mock_std_out[0..7]);
+    }
+
+    #[test]
+    fn single_read_ends_in_newline() {
+        let std_in = vec![
+            String::from("testing\n"),
+        ];
+    }
+
+    // TODO handle windows newlines
+
+    #[test]
+    fn single_read_with_newline() {
+        let std_in = vec![
+            String::from("testing\nis great"),
+        ];
+        let mock_std_in = MockStdIn::new(std_in);
+        let mock_std_out = vec![];
+
+        let mut tee = Tee::new(mock_std_in, mock_std_out);
+
+        let mut buf = [0; 100];
+        assert_eq!(8, tee.read(&mut buf).unwrap());
+        assert_eq!(b"testing\n", &buf[0..8]);
+
+        let mock_std_out = tee.get_writer_ref();
+        assert_eq!(b"testing\n", &mock_std_out[0..8]);
+
+        assert_eq!(8, tee.read(&mut buf).unwrap());
+        assert_eq!(b"is great", &buf[0..8]);
+
+        let mock_std_out = tee.get_writer_ref();
+        assert_eq!(b"is great", &mock_std_out[0..8]);
+    }
+
+    #[test]
+    fn multiline() {
+        let std_in = vec![
+            String::from("testing.."),
+            String::from("."),
+            String::from(".\n."),
+            String::from("is fun"),
+        ];
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ mod tests {
         assert_eq!(b"testing..", &mock_std_out.as_slice());
 
         // second read
+        // should stop at the newline to allow our two outbound streams to sync
         assert_eq!(2, tee.read(&mut buf).unwrap());
         assert_eq!(b".\n", &buf[0..2]);
         let mock_std_out = tee.get_writer_ref();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{io, io::{Read, Write}};
+use std::{
+    io,
+    io::{Read, Write},
+};
 
 pub struct Tee<R, W> {
     reader: R,
@@ -7,12 +10,18 @@ pub struct Tee<R, W> {
     cap: usize,
 }
 
-impl<R, W> Tee<R, W> 
-    where R: Read,
-          W: Write
+impl<R, W> Tee<R, W>
+where
+    R: Read,
+    W: Write,
 {
     pub fn new(reader: R, writer: W) -> Self {
-        Self { reader, writer, buf: [0; 8192], cap: 0 }
+        Self {
+            reader,
+            writer,
+            buf: [0; 8192],
+            cap: 0,
+        }
     }
 
     /// This method must write and flush all bytes so we can
@@ -31,9 +40,10 @@ impl<R, W> Tee<R, W>
     }
 }
 
-impl<R, W> Read for Tee<R, W> 
-    where R: Read,
-          W: Write
+impl<R, W> Read for Tee<R, W>
+where
+    R: Read,
+    W: Write,
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if self.cap > 0 {
@@ -75,7 +85,7 @@ impl<R, W> Read for Tee<R, W>
 
 #[cfg(test)]
 mod tests {
-    use std::{io, {io::Read}};
+    use std::{io, io::Read};
 
     use super::Tee;
 
@@ -111,9 +121,7 @@ mod tests {
 
     #[test]
     fn single_read() {
-        let std_in = vec![
-            String::from("testing"),
-        ];
+        let std_in = vec![String::from("testing")];
         let mock_std_in = MockStdIn::new(std_in);
         let mock_std_out = vec![];
 
@@ -129,9 +137,7 @@ mod tests {
 
     #[test]
     fn single_read_ends_in_newline() {
-        let std_in = vec![
-            String::from("testing\n"),
-        ];
+        let std_in = vec![String::from("testing\n")];
         let mock_std_in = MockStdIn::new(std_in);
         let mock_std_out = vec![];
 
@@ -147,9 +153,7 @@ mod tests {
 
     #[test]
     fn single_read_with_newline() {
-        let std_in = vec![
-            String::from("testing\nis great"),
-        ];
+        let std_in = vec![String::from("testing\nis great")];
         let mock_std_in = MockStdIn::new(std_in);
         let mock_std_out = vec![];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,83 @@
+use std::{io, io::{Read, Write}};
+
+struct Tee<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R, W> Tee<R, W> {
+    fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+
+    fn into_inner(self) -> (R, W) {
+        (self.reader, self.writer)
+    }
+}
+
+impl<R, W> Read for Tee<R, W> 
+    where R: Read,
+          W: Write
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let len = self.reader.read(buf)?;
+        self.writer.write(&buf[0..len]);
+
+        Ok(len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io, {io::Read}};
+
+    use super::Tee;
+
+    struct MockStdIn {
+        inner: Vec<String>,
+    }
+
+    impl MockStdIn {
+        fn new(mut inner: Vec<String>) -> Self {
+            // Reverse the order of the strings because we will pop
+            // them off later and we want them to come off in the order
+            // the user entered them.
+            inner.reverse();
+            Self { inner }
+        }
+    }
+
+    impl Read for MockStdIn {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if let Some(s) = self.inner.pop() {
+                let bytes = s.as_bytes();
+                // This only works if buf is larger than our string, but since
+                // this is only test code and we don't need to exercise that behavior
+                // it is okay.
+                let (left, _right) = buf.split_at_mut(bytes.len());
+                left.copy_from_slice(bytes);
+                Ok(bytes.len())
+            } else {
+                Ok(0) // EOF
+            }
+        }
+    }
+
+    #[test]
+    fn single_line() {
+        let std_in = vec![
+            String::from("testing"),
+        ];
+        let mut mock_std_in = MockStdIn::new(std_in);
+        let mut mock_std_out = vec![];
+
+        let mut tee = Tee::new(mock_std_in, mock_std_out);
+
+        let mut buf = [0; 100];
+        assert_eq!(7, tee.read(&mut buf).unwrap());
+        assert_eq!(b"testing", &buf[0..7]);
+
+        let (_, mock_std_out) = tee.into_inner();
+        assert_eq!(b"testing", &mock_std_out[0..7]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,20 @@ mod tests {
 
     #[test]
     fn single_read_ends_in_newline() {
-        let _std_in = vec![
+        let std_in = vec![
             String::from("testing\n"),
         ];
+        let mock_std_in = MockStdIn::new(std_in);
+        let mock_std_out = vec![];
+
+        let mut tee = Tee::new(mock_std_in, mock_std_out);
+
+        let mut buf = [0; 100];
+        assert_eq!(8, tee.read(&mut buf).unwrap());
+        assert_eq!(b"testing\n", &buf[0..8]);
+
+        let mock_std_out = tee.get_writer_ref();
+        assert_eq!(b"testing\n", &mock_std_out.as_slice());
     }
 
     #[test]

--- a/tests/check.py
+++ b/tests/check.py
@@ -1,0 +1,20 @@
+#!/bin/python3
+
+"""
+This file is useful for manual testing of the buffering behavior
+of estream. Run with `./tests/check.py | ./target/debug/estream`
+and check that estream prints each `.` as it is printed by python
+rather than printing the entire line at once.
+"""
+
+import time
+
+print("testing..", end="", flush=True)
+
+time.sleep(1)
+
+for i in range(5):
+    print(".", end="", flush=True)
+    time.sleep(1)
+    
+print("done")


### PR DESCRIPTION
Ensure we write to std out as soon as we see bytes, but still sync on newlines so output from estream is not interleaved with pass through output. 